### PR TITLE
Support `test-bundled-gems` task on ruby core repository.

### DIFF
--- a/test/test_core_ext_helper.rb
+++ b/test/test_core_ext_helper.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 require 'byebug/core'
 
 class << PowerAssert

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,14 +9,17 @@ begin
 
   require 'bundler'
   Bundler.require
-rescue LoadError
+rescue LoadError, Bundler::GemNotFound
 end
 
 require 'test/unit'
 require 'power_assert'
 require 'ripper'
-require 'byebug'
-require_relative 'test_core_ext_helper'
+
+begin
+  require_relative 'test_core_ext_helper'
+rescue LoadError
+end
 
 module PowerAssertTestHelper
   class << self

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -3,7 +3,6 @@ if defined?(RubyVM) and ! RubyVM::InstructionSequence.compile_option[:specialize
 end
 
 require_relative 'test_helper'
-require 'byebug'
 
 class TestTraceContext < Test::Unit::TestCase
   include PowerAssertTestHelper
@@ -92,4 +91,4 @@ END
       0
 END
   end
-end
+end if defined?(Byebug)


### PR DESCRIPTION
`test-bundled-gems` on ruby core repository could not invoke test suite contained native extension gem. We need to ignore these tests or make to build native extension on `test-bundled-gems`

Therefore, I ignored byebug on tests of power_assert.

* Handle Bundler::GemNotFound exception for simplecov. It used json gem.
* Ignore byebug tests when it's not installed.

@k-tsj How about this patch? I can invoke `test-bundled-gems` task with this changes.