### PR TITLE
Truncate too long lines

### DIFF
--- a/lib/power_assert/context.rb
+++ b/lib/power_assert/context.rb
@@ -6,6 +6,7 @@ require 'power_assert/parser'
 module PowerAssert
   class Context
     Value = Struct.new(:name, :value, :lineno, :column)
+    MAX_LINE_LENGTH = 500
 
     def initialize(base_caller_length)
       @fired = false
@@ -92,10 +93,15 @@ module PowerAssert
           map_to = vals.each_with_object({}) do |j, h|
             h[j.column.to_s.to_sym] = [l, '|', ' '][i.column <=> j.column]
           end
-          lines << encoding_safe_rstrip(sprintf(fmt, map_to))
+          line = encoding_safe_rstrip(sprintf(fmt, map_to))
+          lines << truncate(line, MAX_LINE_LENGTH)
         end
       end
       lines.join("\n")
+    end
+
+    def truncate(line, length)
+      "#{line[0..length]}#{'...' if line.size > length}"
     end
 
     def detect_path(parser, return_values)


### PR DESCRIPTION
`large_object.inspect` returns a very long message. It makes an assertion message hard to read.

In Rails, `ActionDispatch::TestResponse` is large and its `inspect` is over 10000 characters (in my environment)

```
    assert { @response.status == status_code(:forbidden) }
             |                |  |
             |                |  403
             |                false
             #<ActionDispatch::TestResponse:0x00007fc8bd704eb8 @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x00007fc8bd704e18>, @header={"X-Frame-Options"=>"SAMEORIGIN", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "Content-Type"=>"application/json; charset=utf-8", "ETag"=>"W/\"c3ab8ff13720e8ad9047dd39466b3c89\"", "Cache-Control"=>"max-age=0, private, must-revalidate", "X-Request-Id"=>"3c9a5c24-962d-4e2e-9d55-3d4f3fa5c0c0", "X-Runtime"=>"0.078733", "Content-Length"=>"6"}, @stream=#<ActionDispatch::Response::Buffer:0x00007fc8bd704da0 @response=#<ActionDispatch::TestResponse:0x00007fc8bd704eb8 ...>, @buf=["foobar"], @closed=false, @str_body=nil>, @status=200, @cv=#<MonitorMixin::ConditionVariable:0x00007fc8bd704d78 @monitor=#<ActionDispatch::TestResponse:0x00007fc8bd704eb8 ...>, @cond=#<Thread::ConditionVariable:0x00007fc8bd704d50>>, @committed=false, @sending=false, @sent=false, @cache_control={:max_age=>"0", :private=>true, :must_revalidate=>true}...
```

This change truncates each line and make messages more readable.

How do you think?