### PR TITLE
Bug: parsing failed if dyna_symbols as a hash key exists

### DIFF
--- a/lib/power_assert/parser.rb
+++ b/lib/power_assert/parser.rb
@@ -77,7 +77,14 @@ module PowerAssert
       when :opassign
         _, _, (_, op_name, (_, op_column)), s0 = sexp
         extract_idents(s0) + [Ident[:method, op_name.sub(/=\z/, ''), op_column]]
-      when :assoclist_from_args, :bare_assoc_hash, :dyna_symbol, :paren, :string_embexpr,
+      when :dyna_symbol
+        if sexp[1][0].is_a? Symbol
+          # sexp[1] can be [:string_content, [..]] while parsing { "a": 1 }
+          extract_idents(sexp[1])
+        else
+          sexp[1].flat_map {|s| extract_idents(s) }
+        end
+      when :assoclist_from_args, :bare_assoc_hash, :paren, :string_embexpr,
         :regexp_literal, :xstring_literal
         sexp[1].flat_map {|s| extract_idents(s) }
       when :command

--- a/test/dyna_symbol_key_test.rb
+++ b/test/dyna_symbol_key_test.rb
@@ -1,0 +1,32 @@
+if defined?(RubyVM) and ! RubyVM::InstructionSequence.compile_option[:specialized_instruction]
+  warn "#{__FILE__}: specialized_instruction is set to false"
+end
+
+require_relative 'test_helper'
+
+class TestDynaSymbolKey < Test::Unit::TestCase
+  include PowerAssertTestHelper
+
+  data do
+    [
+      ['{"a": b}',
+        [[:method, "b", 6]]],
+    ].each_with_object({}) {|(source, expected_idents, expected_paths), h| h[source] = [expected_idents, expected_paths, source] }
+  end
+  def test_parser(*args)
+    _test_parser(*args)
+  end
+
+  sub_test_case 'branch' do
+    t do
+      assert_equal <<END.chomp, assertion_message {
+        {"a": 1.to_s}.nil?
+                |     |
+                |     false
+                "1"
+END
+        {"a": 1.to_s}.nil?
+      }
+    end
+  end
+end


### PR DESCRIPTION
Fixed `{ "a": 1 }` caused an error inside `Parser#extract_idents` because the AST of the key `"a"` was string_content node `[:string_content, [..]]`, not an array of nodes. (I'm not sure whether it's Ripper's issue or not.)

```ruby
assert { { 'a': 1 } == { 'a': 2 } }

# =>

power_assert: [BUG] Failed to trace: NoMethodError: undefined method `flat_map' for "tring_content":String
          :
	10: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:82:in `each'
	 9: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:82:in `block in extract_idents'
	 8: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:86:in `extract_idents'
	 7: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:86:in `flat_map'
	 6: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:86:in `each'
	 5: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:86:in `block in extract_idents'
	 4: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:82:in `extract_idents'
	 3: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:82:in `flat_map'
	 2: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:82:in `each'
	 1: from /box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:82:in `block in extract_idents'
/box/gems/power_assert-1.1.3/lib/power_assert/parser.rb:86:in `extract_idents': undefined method `flat_map' for "tring_content":String (NoMethodError)
```